### PR TITLE
Fix celldata field attrs

### DIFF
--- a/source/utils/xml/canycontainer.h
+++ b/source/utils/xml/canycontainer.h
@@ -226,7 +226,7 @@ public:
 		if ( myReference && myReference->GetType() != typeid( reference ).name() )
 			return false;
 
-		_Ty tmp;
+		_Ty tmp{}; // Value-init in case GetValue is a no-op for this type
 		GetValue( tmp );
 		return ( tmp == reference );
 	}
@@ -235,7 +235,7 @@ public:
 	template< class _Ty >
 	bool operator < ( const _Ty& reference )
 	{
-		_Ty tmp;
+		_Ty tmp{}; // Value-init in case GetValue is a no-op for this type
 		GetValue( tmp );
 		return reference < tmp;
 	}
@@ -358,7 +358,7 @@ _Ty CAnyContainerCast( const CAnyContainer& container )
 
 	if ( tmp_var == NULL )
 	{
-		_Ty temp_var;
+		_Ty temp_var{}; // Value-init in case GetValue is a no-op for this type
 		container.GetValue( temp_var );
 		return temp_var;
 	}

--- a/source/utils/xml/cvarreference.h
+++ b/source/utils/xml/cvarreference.h
@@ -125,6 +125,20 @@ public:
 
 
     istream& operator>> (bool& val )				{ return istringstream::operator>>(val); }
+    istream& operator>> (signed char& val )
+    {
+        int tmp;
+        istringstream::operator>>(tmp);
+        val = tmp;
+        return *this;
+    }
+    istream& operator>> (unsigned char& val )
+    {
+        unsigned int tmp;
+        istringstream::operator>>(tmp);
+        val = tmp;
+        return *this;
+    }
     istream& operator>> (short& val )				{ return istringstream::operator>>(val); }
     istream& operator>> (unsigned short& val )		{ return istringstream::operator>>(val); }
     istream& operator>> (int& val )					{ return istringstream::operator>>(val); }
@@ -143,6 +157,8 @@ private:
 };
 
 CENG_IS_CENGSTRINGSTREAMABLE_MACROHELPER( bool )
+CENG_IS_CENGSTRINGSTREAMABLE_MACROHELPER( signed char )
+CENG_IS_CENGSTRINGSTREAMABLE_MACROHELPER( unsigned char )
 CENG_IS_CENGSTRINGSTREAMABLE_MACROHELPER( short )
 CENG_IS_CENGSTRINGSTREAMABLE_MACROHELPER( unsigned short )
 CENG_IS_CENGSTRINGSTREAMABLE_MACROHELPER( int )

--- a/source/utils/xml/tests/canycontainer_test.cpp
+++ b/source/utils/xml/tests/canycontainer_test.cpp
@@ -40,6 +40,30 @@ namespace {
 		~CAnyFucker() { }
 		int i;
 	};
+
+	// Struct whose data members are uninitialized if contructed like this:
+	// UninitializedMemory m;
+	// But not when constructed like this
+	// UninitializedMemory m{};
+	struct UninitializedMemory {
+		int a;
+		float x;
+		char c;
+		long data[20];
+
+		bool all_zero()
+		{
+			if (a != 0 || x != 0 || c != 0)
+				return false;
+
+			for (auto d : data)
+			{
+				if (d != 0) return false;
+			}
+
+			return true;
+		}
+	};
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -157,6 +181,12 @@ int CAnyContainerTest()
 			test_assert( tss == "1" );
 
 			CAnyFucker fucked = CAnyContainerCast< CAnyFucker >( test );
+			unsigned char tu8 = CAnyContainerCast< unsigned char > ( test );
+			test_assert( tu8 == 1 );
+
+			signed char ti8 = CAnyContainerCast< signed char > ( test );
+			test_assert( ti8 == 1 );
+
 		}
 
 		{
@@ -191,6 +221,13 @@ int CAnyContainerTest()
 			test_assert( tss == "1" );
 
 			CAnyFucker fucked = CAnyContainerCast< CAnyFucker >( test );
+		}
+
+		// Unknown types should not receive junk memory
+		{
+			test = std::string("hm");
+			UninitializedMemory mem = CAnyContainerCast< UninitializedMemory >( test );
+			test_assert( mem.all_zero() );
 		}
 
 	}


### PR DESCRIPTION
Hiya,

A modder tried setting the gas_speed, gas_upwards_speed, gas_horizontal_speed, gas_downwards_speed in CellData XML but couldn't get them to work right. Turns out there's a bug where (u)int8_t fields receive junk memory because there's no member function `operator>>` for them.

This PR adds deserialisation for these two types. I couldn't test if these exact changes actually fixes the issue in Noita but I think it will. In the long term it might be good to remove the do-nothing `operator>>` on the `stringstream` class but this PR is conservative and doesn't do that. This is how I decided to approach the problem, maybe there's some better way to handle this. Feel free to reject these changes in that case :wink: 

One thing to take note of, `signed char` and `unsigned char` are equivalent to `int8_t` and `uint8_t` from `<stdint.h>`. In C++ `char` is a [completely separate type](https://learn.microsoft.com/en-us/cpp/cpp/fundamental-types-cpp?view=msvc-170#character-types) and no serialisation routine is added for `char`.

The `gas_*_speed` attributes don't occur in the vanilla Noita materials.xml file, so base Noita wasn't affected for those. The `liquid_sprite_stains_check_offset` attribute however *is* being used.. From what I can tell, the 15 materials in materials.xml that set this attribute now always receive the value 5 in this field. Once this change is applied, they'll start receiving different (intended but untested) values.

There are some more details in the commit messages.